### PR TITLE
Support internal functions mock

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,18 @@
 {
     "name": "xepozz/internal-mocker",
     "type": "library",
+    "authors": [
+        {
+            "name": "Dmitrii Derepko",
+            "email": "xepozz@list.ru"
+        }
+    ],
+    "require": {
+        "yiisoft/var-dumper": "^1.2"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^9.5"
+    },
     "autoload": {
         "psr-4": {
             "Xepozz\\InternalMocker\\": "src/"
@@ -10,17 +22,5 @@
         "psr-4": {
             "Xepozz\\InternalMocker\\Tests\\": "tests/"
         }
-    },
-    "authors": [
-        {
-            "name": "Dmitrii Derepko",
-            "email": "xepozz@list.ru"
-        }
-    ],
-    "require-dev": {
-        "phpunit/phpunit": "^9.5"
-    },
-    "require": {
-        "yiisoft/var-dumper": "^1.2"
     }
 }

--- a/tests/Integration/TimeTest.php
+++ b/tests/Integration/TimeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Xepozz\InternalMocker\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use Xepozz\InternalMocker\MockerState;
+
+use function time;
+
+final class TimeTest extends TestCase
+{
+    public function testRun()
+    {
+        $this->assertEquals(`date +%s`, time());
+    }
+
+    public function testRun2()
+    {
+        MockerState::addCondition(
+            '',
+            'time',
+            [],
+            100
+        );
+
+        $this->assertEquals(100, time());
+    }
+
+    public function testRun3()
+    {
+        $this->assertEquals(`date +%s`, time());
+    }
+
+    public function testRun4()
+    {
+        $now = time();
+        sleep(1);
+        $next = time();
+
+        $this->assertEquals(1, $next - $now);
+    }
+}

--- a/tests/MockerExtension.php
+++ b/tests/MockerExtension.php
@@ -69,6 +69,11 @@ final class MockerExtension implements BeforeFirstTestHook, BeforeTestHook
                 'namespace' => 'ASD',
                 'name' => 'only_runtime',
             ],
+            [
+                'namespace' => '',
+                'name' => 'time',
+                'function' => fn () => `date +%s`,
+            ],
         ];
 
         $mocker = new Mocker();

--- a/tests/MockerTest.php
+++ b/tests/MockerTest.php
@@ -5,7 +5,6 @@ namespace Xepozz\InternalMocker\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Xepozz\InternalMocker\Mocker;
-use Xepozz\InternalMocker\MockerState;
 
 final class MockerTest extends TestCase
 {
@@ -32,7 +31,9 @@ final class MockerTest extends TestCase
                     ],
                 ],
                 <<<PHP
-                namespace Xepozz\InternalMocker;
+                namespace {
+                use Xepozz\InternalMocker\MockerState;
+                
                 MockerState::addCondition(
                     "Xepozz\InternalMocker\Tests\Integration", 
                     "time",
@@ -40,10 +41,10 @@ final class MockerTest extends TestCase
                     555,
                     false,
                 );
+                }
                 
                 
-                namespace Xepozz\InternalMocker\Tests\Integration;
-                
+                namespace Xepozz\InternalMocker\Tests\Integration {
                 use Xepozz\InternalMocker\MockerState;
                 
                 function time(...\$arguments)
@@ -52,6 +53,7 @@ final class MockerTest extends TestCase
                         return MockerState::getResult(__NAMESPACE__, "time", \$arguments);
                     }
                     return MockerState::getDefaultResult(__NAMESPACE__, "time", fn() => \\time(...\$arguments));
+                }
                 }
                 PHP,
             ],
@@ -77,7 +79,9 @@ final class MockerTest extends TestCase
                     ],
                 ],
                 <<<PHP
-                namespace Xepozz\InternalMocker;
+                namespace {
+                use Xepozz\InternalMocker\MockerState;
+                
                 MockerState::addCondition(
                     "Xepozz\InternalMocker\Tests\Integration", 
                     "str_contains",
@@ -92,10 +96,10 @@ final class MockerTest extends TestCase
                     false,
                     false,
                 );
+                }
 
 
-                namespace Xepozz\InternalMocker\Tests\Integration;
-                
+                namespace Xepozz\InternalMocker\Tests\Integration {
                 use Xepozz\InternalMocker\MockerState;
 
                 function str_contains(...\$arguments)
@@ -104,6 +108,7 @@ final class MockerTest extends TestCase
                         return MockerState::getResult(__NAMESPACE__, "str_contains", \$arguments);
                     }
                     return MockerState::getDefaultResult(__NAMESPACE__, "str_contains", fn() => \\str_contains(...\$arguments));
+                }
                 }
                 PHP,
             ],


### PR DESCRIPTION
```php
<?php

declare(strict_types=1);

namespace Xepozz\InternalMocker\Tests\Integration;

use PHPUnit\Framework\TestCase;
use Xepozz\InternalMocker\MockerState;

use function time;

final class TimeTest extends TestCase
{
    public function testRun()
    {
        $this->assertEquals(`date +%s`, time());
    }

    public function testRun2()
    {
        MockerState::addCondition(
            '',
            'time',
            [],
            100
        );

        $this->assertEquals(100, time());
    }

    public function testRun3()
    {
        $this->assertEquals(`date +%s`, time());
    }

    public function testRun4()
    {
        $now = time();
        sleep(1);
        $next = time();

        $this->assertEquals(1, $next - $now);
    }
}
```